### PR TITLE
🐛 Fix error deserialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "@essential-projects/bootstrapper_contracts": "^1.3.0",
-    "@essential-projects/errors_ts": "^1.4.0",
+    "@essential-projects/errors_ts": "feature~fix_error_serialization",
     "@essential-projects/sequelize_connection_manager": "^2.1.0",
     "@process-engine/external_task_api_contracts": "^1.0.0",
     "node-uuid": "^1.4.8",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "@essential-projects/bootstrapper_contracts": "^1.3.0",
-    "@essential-projects/errors_ts": "feature~fix_error_serialization",
+    "@essential-projects/errors_ts": "^1.4.5",
     "@essential-projects/sequelize_connection_manager": "^2.1.0",
     "@process-engine/external_task_api_contracts": "^1.0.0",
     "node-uuid": "^1.4.8",

--- a/src/external_task_repository.ts
+++ b/src/external_task_repository.ts
@@ -271,11 +271,10 @@ export class ExternalTaskRepository implements IExternalTaskRepository, IDisposa
       const essentialProjectsError: Error = this._tryDeserializeEssentialProjectsError(dataModel.error);
 
       const errorIsFromEssentialProjects: boolean = essentialProjectsError !== undefined;
-      if (errorIsFromEssentialProjects) {
-        error = essentialProjectsError;
-      } else {
-        error = this._tryParse(dataModel.error);
-      }
+
+      error = errorIsFromEssentialProjects
+        ? essentialProjectsError
+        : this._tryParse(dataModel.error);
     }
 
     return [identity, payload, result, error];

--- a/src/external_task_repository.ts
+++ b/src/external_task_repository.ts
@@ -4,7 +4,7 @@ import * as uuid from 'node-uuid';
 import * as Sequelize from 'sequelize';
 
 import {IDisposable} from '@essential-projects/bootstrapper_contracts';
-import {NotFoundError} from '@essential-projects/errors_ts';
+import {BaseError, isEssentialProjectsError, NotFoundError} from '@essential-projects/errors_ts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 import {SequelizeConnectionManager} from '@essential-projects/sequelize_connection_manager';
 import {
@@ -183,7 +183,7 @@ export class ExternalTaskRepository implements IExternalTaskRepository, IDisposa
       },
     });
 
-    externalTask.error = JSON.stringify(error);
+    externalTask.error = this._serializeError(error);
     externalTask.state = ExternalTaskState.finished;
     externalTask.finishedAt = moment().toDate();
     await externalTask.save();
@@ -201,6 +201,21 @@ export class ExternalTaskRepository implements IExternalTaskRepository, IDisposa
     externalTask.state = ExternalTaskState.finished;
     externalTask.finishedAt = moment().toDate();
     await externalTask.save();
+  }
+
+  private _serializeError(error: any): string {
+
+    const errorIsFromEssentialProjects: boolean = isEssentialProjectsError(error);
+    if (errorIsFromEssentialProjects) {
+      return (error as BaseError).serialize();
+    }
+
+    const errorIsString: boolean = typeof error === 'string';
+    if (errorIsString) {
+      return error;
+    }
+
+    return JSON.stringify(error);
   }
 
   /**
@@ -237,21 +252,49 @@ export class ExternalTaskRepository implements IExternalTaskRepository, IDisposa
 
   private _sanitizeDataModel(dataModel: ExternalTaskModel): Array<any> {
     const identity: any = dataModel.identity
-      ? JSON.parse(dataModel.identity)
+      ? this._tryParse(dataModel.identity)
       : undefined;
 
     const payload: any = dataModel.payload
-      ? JSON.parse(dataModel.payload)
+      ? this._tryParse(dataModel.payload)
       : undefined;
 
     const result: any = dataModel.result
-      ? JSON.parse(dataModel.result)
+      ? this._tryParse(dataModel.result)
       : undefined;
 
-    const error: any = dataModel.error
-      ? JSON.parse(dataModel.error)
-      : undefined;
+    let error: Error;
+
+    const dataModelHasError: boolean = dataModel.error !== undefined;
+    if (dataModelHasError) {
+
+      const essentialProjectsError: Error = this._tryDeserializeEssentialProjectsError(dataModel.error);
+
+      const errorIsFromEssentialProjects: boolean = essentialProjectsError !== undefined;
+      if (errorIsFromEssentialProjects) {
+        error = essentialProjectsError;
+      } else {
+        error = this._tryParse(dataModel.error);
+      }
+    }
 
     return [identity, payload, result, error];
+  }
+
+  private _tryParse(value: string): any {
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      // Value is not a JSON - return it as it is.
+      return value;
+    }
+  }
+
+  private _tryDeserializeEssentialProjectsError(value: string): Error {
+    try {
+      return BaseError.deserialize(value);
+    } catch (error) {
+      return undefined;
+    }
   }
 }


### PR DESCRIPTION
**Changes:**

`JSON.stringify` does not include an error's message with the string.
To get around this problem, the repository will now make use of the `@essential-project/error_ts` serialization/deserialization feature to store errors, if possible.
Most errors we pass around come from that package anyway, so we should be fine with this. 

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/309

PR: #8

## How can others test the changes?

- Run an ExternalTask that ends with an error.
- When that error gets persisted, the serialized string of that error gets stored.
- When retrieving the ExternalTask from the database, the error is fully deserialized.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).